### PR TITLE
Cipher Suite Handling Improvements

### DIFF
--- a/pyghmi/ipmi/private/cipher_suite.py
+++ b/pyghmi/ipmi/private/cipher_suite.py
@@ -1,3 +1,16 @@
+# Copyright 2013 IBM Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 """Cipher suite configuration shared by session modules."""
 
@@ -25,7 +38,6 @@ CIPHER_SUITE_PARAMS = {
     16: (3, 4, 0),
     17: (3, 4, 1),
 }
-
 
 def build_cipher_suite(auth: int, integ: int, conf: int) -> bytearray:
     """Construct the 24-byte encoding for a cipher suite."""

--- a/pyghmi/ipmi/private/cipher_suite.py
+++ b/pyghmi/ipmi/private/cipher_suite.py
@@ -1,0 +1,39 @@
+
+"""Cipher suite configuration shared by session modules."""
+
+import struct
+
+# Map of cipher suite identifiers to authentication, integrity and
+# confidentiality algorithm identifiers.
+CIPHER_SUITE_PARAMS = {
+    0: (0, 0, 0),
+    1: (1, 0, 0),
+    2: (1, 1, 0),
+    3: (1, 1, 1),
+    4: (1, 1, 2),
+    5: (1, 1, 3),
+    6: (2, 0, 0),
+    7: (2, 2, 0),
+    8: (2, 2, 1),
+    9: (2, 2, 2),
+    10: (2, 2, 3),
+    11: (2, 3, 0),
+    12: (2, 3, 1),
+    13: (2, 3, 2),
+    14: (2, 3, 3),
+    15: (3, 0, 0),
+    16: (3, 4, 0),
+    17: (3, 4, 1),
+}
+
+
+def build_cipher_suite(auth: int, integ: int, conf: int) -> bytearray:
+    """Construct the 24-byte encoding for a cipher suite."""
+    return (
+        bytearray(b"\x00\x00\x00\x08")
+        + struct.pack("<I", auth)
+        + b"\x01\x00\x00\x08"
+        + struct.pack("<I", integ)
+        + b"\x02\x00\x00\x08"
+        + struct.pack("<I", conf)
+    )

--- a/pyghmi/ipmi/private/serversession.py
+++ b/pyghmi/ipmi/private/serversession.py
@@ -39,7 +39,33 @@ class ServerSession(ipmisession.Session):
         return object.__new__(cls)
 
     def create_open_session_response(self, request):
+        requested_suite = request[8:24+8]
+        suites = {
+            3: bytearray([
+                0, 0, 0, 8, 1, 0, 0, 0,  # table 13-17, SHA-1
+                1, 0, 0, 8, 1, 0, 0, 0,  # SHA-1 integrity
+                2, 0, 0, 8, 1, 0, 0, 0,  # AES privacy
+            ]),
+            6: bytearray([
+                0, 0, 0, 8, 3, 0, 0, 0,  # table 13-17, SHA-256
+                1, 0, 0, 8, 4, 0, 0, 0,  # SHA-256-128 integrity
+                2, 0, 0, 8, 1, 0, 0, 0,  # AES privacy
+            ])
+        }
+
+        matching_suite = None
+        for key, value in suites.items():
+            if value == requested_suite:
+                matching_suite = key
+                break
+
         clienttag = request[0]
+
+        # if the requested suite doesn't match one we support send 11h error aka decimal 17
+        if matching_suite is None:
+            response = bytearray([clienttag, 17])
+            return response
+        
         # role = request[1]
         self.clientsessionid = request[4:8]
         # TODO(jbjohnso): intelligently handle integrity/auth/conf
@@ -49,18 +75,29 @@ class ServerSession(ipmisession.Session):
         # table 13-18, integrity, 1 for now is hmac-sha1-96, 4 is sha256
         # confidentiality: 1 is aes-cbc-128, the only one
         self.privlevel = 4
+
+        self.requested_suite = matching_suite
+        self.requested_suite_data = suites[matching_suite]
+
+        if self.requested_suite == 3:
+            self.currhashlib = hashlib.sha1
+            self.currhashlen = 12
+        elif self.requested_suite == 6:
+            self.currhashlib = hashlib.sha256
+            self.currhashlen = 16
+
         response = (bytearray([clienttag, 0, self.privlevel, 0])
-                    + self.clientsessionid + self.managedsessionid
-                    + bytearray([
-                        0, 0, 0, 8, 1, 0, 0, 0,  # auth
-                        1, 0, 0, 8, 1, 0, 0, 0,  # integrity
-                        2, 0, 0, 8, 1, 0, 0, 0,  # privacy
-                    ]))
+            + self.clientsessionid + self.managedsessionid
+            + self.requested_suite_data)
         return response
 
     def __init__(self, authdata, kg, clientaddr, netsocket, request, uuid,
                  bmc):
         # begin conversation per RMCP+ open session request
+
+        self.requested_suite = 0
+        self.requested_suite_data = []
+
         self.uuid = uuid
         self.currhashlib = hashlib.sha1
         self.currhashlen = 12
@@ -123,7 +160,7 @@ class ServerSession(ipmisession.Session):
         if self.kg is None:
             self.kg = self.kuid
         authcode = hmac.new(
-            self.kuid, bytes(hmacdata), hashlib.sha1).digest()
+            self.kuid, bytes(hmacdata), self.currhashlib).digest()
         # regretably, ipmi mandates the server send out an hmac first
         # akin to a leak of /etc/shadow, not too worrisome if the secret
         # is complex, but terrible for most likely passwords selected by
@@ -146,14 +183,14 @@ class ServerSession(ipmisession.Session):
         self.sik = hmac.new(self.kg,
                             bytes(RmRc)
                             + struct.pack("2B", self.rolem, len(self.username))
-                            + self.username, hashlib.sha1).digest()
-        self.k1 = hmac.new(self.sik, b'\x01' * 20, hashlib.sha1).digest()
-        self.k2 = hmac.new(self.sik, b'\x02' * 20, hashlib.sha1).digest()
+                            + self.username, self.currhashlib).digest()
+        self.k1 = hmac.new(self.sik, b'\x01' * 20, self.currhashlib).digest()
+        self.k2 = hmac.new(self.sik, b'\x02' * 20, self.currhashlib).digest()
         self.aeskey = self.k2[0:16]
         hmacdata = (self.Rc + self.clientsessionid
                     + struct.pack("2B", self.rolem, len(self.username))
                     + self.username)
-        expectedauthcode = hmac.new(self.kuid, bytes(hmacdata), hashlib.sha1
+        expectedauthcode = hmac.new(self.kuid, bytes(hmacdata), self.currhashlib
                                     ).digest()
         authcode = struct.pack("%dB" % len(data[8:]), *data[8:])
         if expectedauthcode != authcode:
@@ -192,7 +229,7 @@ class ServerSession(ipmisession.Session):
             [tagvalue, statuscode, 0, 0]) + self.clientsessionid
         hmacdata = self.Rm + self.managedsessionid + self.uuiddata
         hmacdata = struct.pack('%dB' % len(hmacdata), *hmacdata)
-        authdata = hmac.new(self.sik, hmacdata, hashlib.sha1).digest()[:12]
+        authdata = hmac.new(self.sik, hmacdata, self.currhashlib).digest()[:self.currhashlen]
         payload += authdata
         self.send_payload(payload, constants.payload_types['rakp4'],
                           retry=False)

--- a/pyghmi/ipmi/private/serversession.py
+++ b/pyghmi/ipmi/private/serversession.py
@@ -146,7 +146,10 @@ class ServerSession(ipmisession.Session):
             return
         self.username = bytes(data[28:])
         if self.username.decode('utf-8') not in self.authdata:
-            # don't think about invalid usernames for now
+            # respond to the client with a 0Dh error code
+            self.send_payload(bytearray([clienttag, 0x0d]),
+                              constants.payload_types['rakp2'],
+                              retry=False)
             return
         uuidbytes = self.uuid.bytes
         self.uuiddata = uuidbytes

--- a/pyghmi/ipmi/private/serversession.py
+++ b/pyghmi/ipmi/private/serversession.py
@@ -139,12 +139,15 @@ suites: dict[int, bytearray] = {
     ]),
 }
 
+supported_suites: list[int] = [3, 8, 17]
+
 print("Available cipher suites:")
 for key, value in suites.items():
     print(f"Suite {key}: {value.hex()} (Rakp: {value[0:4].hex()}, "
           f"Integ: {value[4:8].hex()}, Conf: {value[8:12].hex()})")
 
 class ServerSession(ipmisession.Session):
+
     def __new__(cls, authdata, kg, clientaddr, netsocket, request, uuid,
                 bmc):
         # Need to do default new type behavior.  The normal session
@@ -153,10 +156,10 @@ class ServerSession(ipmisession.Session):
         # with in the server case (one file descriptor per bmc)
         return object.__new__(cls)
 
-    def create_open_session_response(self, request):
+    def create_open_session_response(self, request: bytearray) -> bytearray:
         requested_suite = request[8:24+8]
 
-        print("Requested cipher suite: {}".format(requested_suite.hex()))
+        print(f"Requested cipher suite: {format(requested_suite.hex())}")
 
         matching_suite = None
         for key, value in suites.items():
@@ -164,24 +167,17 @@ class ServerSession(ipmisession.Session):
                 matching_suite = key
                 break
 
-        clienttag = request[0]
+        clienttag = int(request[0])
 
         # if the requested suite doesn't match one we support send 11h error aka decimal 17
-        if matching_suite is None:
-            response = bytearray([clienttag, 17])
-            return response
-
-        # if matching_suite isn't in 3, 8, 17 send 11h error aka decimal 17
-        # this is temporary whilst we figure the rest out
-        if matching_suite not in (3, 8, 17):
-            response = bytearray([clienttag, 17])
-            return response
+        if matching_suite is None or matching_suite not in supported_suites:
+            return bytearray([clienttag, 17])
         
         # role = request[1]
         self.clientsessionid = request[4:8]
         # TODO(jbjohnso): intelligently handle integrity/auth/conf
         # for now, forcibly do cipher suite 3
-        self.managedsessionid = os.urandom(4)
+        self.managedsessionid: bytes = os.urandom(4)
         # table 13-17, 1 for now (hmac-sha1), 3 should also be supported
         # table 13-18, integrity, 1 for now is hmac-sha1-96, 4 is sha256
         # confidentiality: 1 is aes-cbc-128, the only one
@@ -189,41 +185,30 @@ class ServerSession(ipmisession.Session):
 
         self.requested_suite = matching_suite
 
-        print("Requested cipher suite: {}".format(self.requested_suite))
+        print(f"Requested cipher suite: {format(self.requested_suite)}")
 
         self.requested_suite_data = suites[matching_suite]
 
-        integrity = int.from_bytes(self.requested_suite_data[4:8], 'little')
+        integrity: int = int.from_bytes(self.requested_suite_data[4:8], 'little')
+        print(f"Integrity algorithm selected: {format(integrity)}")
 
-        print("Integrity algorithm selected: {}".format(integrity))
+        algo_map = {
+            1: (hashlib.sha1, 12),
+            2: (hashlib.md5, 16),
+            3: (hashlib.sha256, 16)
+        }
+        try:
+            self.currhashlib
+            self.currhashlen = algo_map[integrity]
+        except KeyError:
+            return bytearray([clienttag, 17])
 
-        if integrity == 1:
-            # hmac-sha1-96
-            self.currhashlib = hashlib.sha1
-            self.currhashlen = 12
-        elif integrity == 2:
-            # hmac-md5-128
-            self.currhashlib = hashlib.md5
-            self.currhashlen = 16
-        elif integrity == 3:
-            # hmac-sha256-128
-            self.currhashlib = hashlib.sha256
-            self.currhashlen = 16
-        else:
-            # throw an error here, unsupported integrity algo
-            # null is not supported, so we don't support suite 0
-            # though we include it in the suite list for reference
-            raise ValueError("Unsupported integrity algorithm: {}".format(integrity))
-
-        #self.integrityalgo: int = integrity
-
-        response = (bytearray([clienttag, 0, self.privlevel, 0])
+        response = bytearray(bytearray([clienttag, 0, self.privlevel, 0])
             + self.clientsessionid + self.managedsessionid
             + self.requested_suite_data)
         return response
 
-    def __init__(self, authdata, kg, clientaddr, netsocket, request, uuid,
-                 bmc):
+    def __init__(self, authdata, kg, clientaddr, netsocket, request, uuid, bmc):
         # begin conversation per RMCP+ open session request
 
         self.requested_suite = 0

--- a/pyghmi/ipmi/private/serversession.py
+++ b/pyghmi/ipmi/private/serversession.py
@@ -191,19 +191,18 @@ class ServerSession(ipmisession.Session):
 
         print("Integrity algorithm selected: {}".format(integrity))
 
-        if integrity == 2:
-            # hmac-md5-128
-            self.currhashlib = hashlib.md5
-            self.currhashlen = 16
-        elif integrity == 1:
+        if integrity == 1:
             # hmac-sha1-96
             self.currhashlib = hashlib.sha1
             self.currhashlen = 12
-        elif integrity == 4:
+        elif integrity == 2:
+            # hmac-md5-128
+            self.currhashlib = hashlib.md5
+            self.currhashlen = 16
+        elif integrity == 3:
             # hmac-sha256-128
             self.currhashlib = hashlib.sha256
             self.currhashlen = 16
-
         else:
             # throw an error here, unsupported integrity algo
             # null is not supported, so we don't support suite 0

--- a/pyghmi/ipmi/private/serversession.py
+++ b/pyghmi/ipmi/private/serversession.py
@@ -28,28 +28,15 @@ import uuid
 import pyghmi.ipmi.private.constants as constants
 import pyghmi.ipmi.private.session as ipmisession
 
-# used to build our suite records, which are 24 bytes long
-def make_suite(rakp_id: int, integ_id: int, conf_id: int) -> bytearray:
+def make_suite(integrity: int, confidentiality: int, rakp: int) -> bytes:
+    """Creates a cipher suite byte array.
+
+    :param integrity: The integrity algorithm code (e.g., 0x04 for HMAC-MD5)
+    :param confidentiality: The confidentiality algorithm code (e.g., 0x01 for AES-128)
+    :param rakp: The RAKP algorithm code (e.g., 0x03 for AES-128)
+    :return: A byte array representing the cipher suite
     """
-    Build a 24-byte record in the exact format that ipmitool (and most BMCs)
-    actually send for “Get Cipher Suite Privilege”:
-
-      Row 0: [0,0,0, rakp_id] [integ_id,0,0,0]
-      Row 1: [integ_id,0,0, rakp_id] [integ_id,0,0,0]
-      Row 2: [conf_id,0,0, rakp_id] [integ_id,0,0,0]
-
-    i.e. each “row” is 8 bytes, so 3 rows × 8 bytes = 24 bytes total.
-    """
-    # Row 0
-    row0 = bytes([0, 0, 0, rakp_id, integ_id, 0, 0, 0])
-
-    # Row 1
-    row1 = bytes([integ_id, 0, 0, rakp_id, integ_id, 0, 0, 0])
-
-    # Row 2
-    row2 = bytes([conf_id, 0, 0, rakp_id, integ_id, 0, 0, 0])
-
-    return bytearray(row0 + row1 + row2)
+    return struct.pack('>IIBB', integrity, confidentiality, rakp, 0, 0)
 
 suites = {
     0:  make_suite(0x00, 0x00, 0x00),  # Null/no-auth/no-int/no-conf

--- a/pyghmi/ipmi/private/serversession.py
+++ b/pyghmi/ipmi/private/serversession.py
@@ -202,8 +202,8 @@ class ServerSession(ipmisession.Session):
             6: (hashlib.sha512, 24),
         }
         try:
-            self.currhashlib
-            self.currhashlen = algo_map[self.integrityalgo]
+            self.currhashlib = algo_map[self.integrityalgo][0]
+            self.currhashlen = algo_map[self.integrityalgo][1]
         except KeyError:
             return bytearray([clienttag, 17])
 

--- a/pyghmi/ipmi/private/serversession.py
+++ b/pyghmi/ipmi/private/serversession.py
@@ -35,6 +35,7 @@ from pyghmi.ipmi.private.cipher_suite import (
 suites: dict[int, bytearray] = {
     sid: build_cipher_suite(*algos)
     for sid, algos in CIPHER_SUITE_PARAMS.items()
+}
 
 supported_suites: list[int] = list(suites.keys())
 

--- a/pyghmi/ipmi/private/serversession.py
+++ b/pyghmi/ipmi/private/serversession.py
@@ -59,6 +59,11 @@ suites = {
     17: make_suite(0x0B, 0x04, 0x03),  # HMAC-SHA256 + AES-256
 }
 
+print("Available cipher suites:")
+for key, value in suites.items():
+    print(f"Suite {key}: {value.hex()} (Rakp: {value[0:4].hex()}, "
+          f"Integ: {value[4:8].hex()}, Conf: {value[8:12].hex()})")
+
 class ServerSession(ipmisession.Session):
     def __new__(cls, authdata, kg, clientaddr, netsocket, request, uuid,
                 bmc):
@@ -98,6 +103,8 @@ class ServerSession(ipmisession.Session):
         self.requested_suite_data = suites[matching_suite]
 
         integrity = int.from_bytes(self.requested_suite_data[4:8], "big")
+
+        print("Integrity algorithm selected: {}".format(integrity))
 
         if integrity == 0x00000001:
             self.currhashlib = hashlib.sha1

--- a/pyghmi/ipmi/private/serversession.py
+++ b/pyghmi/ipmi/private/serversession.py
@@ -31,18 +31,25 @@ import pyghmi.ipmi.private.session as ipmisession
 # used to build our suite records, which are 24 bytes long
 def make_suite(rakp_id: int, integ_id: int, conf_id: int) -> bytearray:
     """
-    Build a 24-byte IPMI LAN+ cipher-suite record by repeating
-    the three 32-bit (big-endian) IDs twice.
+    Build a 24-byte record in the exact format that ipmitool (and most BMCs)
+    actually send for “Get Cipher Suite Privilege”:
+
+      Row 0: [0,0,0, rakp_id] [integ_id,0,0,0]
+      Row 1: [integ_id,0,0, rakp_id] [integ_id,0,0,0]
+      Row 2: [conf_id,0,0, rakp_id] [integ_id,0,0,0]
+
+    i.e. each “row” is 8 bytes, so 3 rows × 8 bytes = 24 bytes total.
     """
-    rakp_bytes: bytes = rakp_id.to_bytes(4, "big")
-    integ_bytes: bytes = integ_id.to_bytes(4, "big")
-    conf_bytes: bytes = conf_id.to_bytes(4, "big")
+    # Row 0
+    row0 = bytes([0, 0, 0, rakp_id, integ_id, 0, 0, 0])
 
-    # Concatenate three `bytes` → one 12‐byte `bytes`
-    trio: bytes = rakp_bytes + integ_bytes + conf_bytes
+    # Row 1
+    row1 = bytes([integ_id, 0, 0, rakp_id, integ_id, 0, 0, 0])
 
-    # Repeat that 12 bytes to get 24 bytes, then wrap in bytearray
-    return bytearray(trio + trio)
+    # Row 2
+    row2 = bytes([conf_id, 0, 0, rakp_id, integ_id, 0, 0, 0])
+
+    return bytearray(row0 + row1 + row2)
 
 suites = {
     0:  make_suite(0x00, 0x00, 0x00),  # Null/no-auth/no-int/no-conf

--- a/pyghmi/ipmi/private/serversession.py
+++ b/pyghmi/ipmi/private/serversession.py
@@ -28,33 +28,17 @@ import uuid
 import pyghmi.ipmi.private.constants as constants
 import pyghmi.ipmi.private.session as ipmisession
 
-def make_suite(rakp: int, integ: int, conf: int) -> bytearray:
-    """
-    Build the 24-byte "ipmitool" format for an IPMI 2.0 LAN+ cipher suite.
-    Each 8-byte row is:
-      Row 0: [0, 0, 0, rakp] + [integ, 0, 0, 0]
-      Row 1: [integ, 0, 0, rakp] + [integ, 0, 0, 0]
-      Row 2: [conf, 0, 0, rakp] + [integ, 0, 0, 0]
-    """
-    row0 = bytes([0x00, 0x00, 0x00, rakp, integ, 0x00, 0x00, 0x00])
-    row1 = bytes([integ, 0x00, 0x00, rakp, integ, 0x00, 0x00, 0x00])
-    row2 = bytes([conf,  0x00, 0x00, rakp, integ, 0x00, 0x00, 0x00])
-    return bytearray(row0 + row1 + row2)
-
-# Standard non-OEM suites (ID: (rakp, integ, conf)):
-suites: dict[int, bytearray] = {
-    0:  make_suite(0x00, 0x00, 0x00),  # Null/no-auth/no-int/no-conf
-    1:  make_suite(0x04, 0x02, 0x00),  # HMAC-MD5, no privacy
-    2:  make_suite(0x08, 0x01, 0x07),  # HMAC-SHA1 + DES
-    3:  make_suite(0x08, 0x01, 0x01),  # HMAC-SHA1 + AES-128
-    6:  make_suite(0x0B, 0x04, 0x01),  # HMAC-SHA256 + AES-128
-    7:  make_suite(0x08, 0x01, 0x03),  # HMAC-SHA1 + AES-256
-    8:  make_suite(0x0B, 0x04, 0x01),  # HMAC-SHA256 + AES-128 (same as 6)
-    11: make_suite(0x08, 0x01, 0x04),  # HMAC-SHA1 + 3DES
-    12: make_suite(0x0B, 0x04, 0x02),  # HMAC-SHA256 + AES-192
-    15: make_suite(0x08, 0x01, 0x05),  # HMAC-SHA1 + AES-128-GCM
-    16: make_suite(0x0B, 0x04, 0x05),  # HMAC-SHA256 + AES-128-GCM
-    17: make_suite(0x0B, 0x04, 0x03),  # HMAC-SHA256 + AES-256
+suites = {
+    3: bytearray([
+        0, 0, 0, 8, 1, 0, 0, 0,  # table 13-17, SHA-1
+        1, 0, 0, 8, 1, 0, 0, 0,  # SHA-1 integrity
+        2, 0, 0, 8, 1, 0, 0, 0,  # AES privacy
+    ]),
+    6: bytearray([
+        0, 0, 0, 8, 3, 0, 0, 0,  # table 13-17, SHA-256
+        1, 0, 0, 8, 4, 0, 0, 0,  # SHA-256-128 integrity
+        2, 0, 0, 8, 1, 0, 0, 0,  # AES privacy
+    ])
 }
 
 print("Available cipher suites:")

--- a/pyghmi/ipmi/private/serversession.py
+++ b/pyghmi/ipmi/private/serversession.py
@@ -356,8 +356,9 @@ class ServerSession(ipmisession.Session):
         payload += authdata
         self.send_payload(payload, constants.payload_types['rakp4'],
                           retry=False)
-        self.confalgo = 'aes'
-        self.integrityalgo = 'sha1'
+        # Use the algorithms selected during open session negotiation
+        self.confalgo = self.requested_confalgo
+        self.integrityalgo = self.requested_integrityalgo
         self.sequencenumber = 1
         self.sessionid = struct.unpack(
             '<I', struct.pack('4B', *self.clientsessionid))[0]

--- a/pyghmi/ipmi/private/serversession.py
+++ b/pyghmi/ipmi/private/serversession.py
@@ -184,10 +184,13 @@ class ServerSession(ipmisession.Session):
 
         self.requested_suite_data = suites[matching_suite]
 
-        integrity: int = int.from_bytes(self.requested_suite_data[4:8], 'little')
-        print(f"Integrity algorithm selected: {format(integrity)}")
+        # not implemented yet
+        # auth  = int.from_bytes(self.requested_suite_data[4:8], 'little')
 
-        self.confalgo: int = int.from_bytes(self.requested_suite_data[8:12], 'little')
+        self.integrityalgo: int.from_bytes(self.requested_suite_data[12:16], 'little')
+        print(f"Integrity algorithm selected: {format(self.integrityalgo)}")
+
+        self.confalgo: int  = int.from_bytes(self.requested_suite_data[20:24], 'little')
         print(f"Confidentiality algorithm selected: {format(self.confalgo)}")
 
         algo_map = {
@@ -200,8 +203,7 @@ class ServerSession(ipmisession.Session):
         }
         try:
             self.currhashlib
-            self.currhashlen = algo_map[integrity]
-            self.integrityalgo = integrity
+            self.currhashlen = algo_map[self.integrityalgo]
         except KeyError:
             return bytearray([clienttag, 17])
 

--- a/pyghmi/ipmi/private/serversession.py
+++ b/pyghmi/ipmi/private/serversession.py
@@ -28,6 +28,22 @@ import uuid
 import pyghmi.ipmi.private.constants as constants
 import pyghmi.ipmi.private.session as ipmisession
 
+# used to build our suite records, which are 24 bytes long
+def make_suite(rakp_id: int, integ_id: int, conf_id: int) -> bytearray:
+    """
+    Build a 24-byte IPMI LAN+ cipher-suite record by repeating
+    the three 32-bit (big-endian) IDs twice.
+    """
+    rakp_bytes: bytes = rakp_id.to_bytes(4, "big")
+    integ_bytes: bytes = integ_id.to_bytes(4, "big")
+    conf_bytes: bytes = conf_id.to_bytes(4, "big")
+
+    # Concatenate three `bytes` → one 12‐byte `bytes`
+    trio: bytes = rakp_bytes + integ_bytes + conf_bytes
+
+    # Repeat that 12 bytes to get 24 bytes, then wrap in bytearray
+    return bytearray(trio + trio)
+
 suites = {
     0:  make_suite(0x00, 0x00, 0x00),  # Null/no-auth/no-int/no-conf
     1:  make_suite(0x04, 0x02, 0x00),  # HMAC-MD5, no privacy
@@ -445,21 +461,3 @@ class IpmiServer(object):
 
     def logout(self):
         pass
-
-# used to build our suite records, which are 24 bytes long
-def make_suite(rakp_id, integ_id, conf_id):
-    """
-    Build a 24-byte IPMI LAN+ cipher-suite record by repeating
-    the three 32-bit (big-endian) IDs twice.
-    """
-    trio = (
-        rakp_id.to_bytes(4, "big") +
-        integ_id.to_bytes(4, "big") +
-        conf_id.to_bytes(4, "big")
-    )
-
-    # 8 bytes × 2 = 16 bytes? No—8 bytes × 3 = 24 bytes
-    # each (RAKP, Integrity, Confidentiality) is 3 × 4 = 12 bytes,
-    # so “trio” is 12 bytes, and “trio + trio” is 24 bytes total.
-    # (RAKP.to_bytes(4) + Integ.to_bytes(4) + Conf.to_bytes(4)) is 12 bytes; repeating it gives 24.
-    return trio + trio

--- a/pyghmi/ipmi/private/serversession.py
+++ b/pyghmi/ipmi/private/serversession.py
@@ -28,17 +28,115 @@ import uuid
 import pyghmi.ipmi.private.constants as constants
 import pyghmi.ipmi.private.session as ipmisession
 
-suites = {
+suites: dict[int, bytearray] = {
+    0: bytearray([
+        # Suite 0: “no auth, no integ, no conf”
+        0,0,0,8,   0,0,0,0,  
+        1,0,0,8,   0,0,0,0,  
+        2,0,0,8,   0,0,0,0,
+    ]),
+    1: bytearray([
+        # Suite 1: RAKP-HMAC-SHA1 (0x01), none, none
+        0,0,0,8,   1,0,0,0,
+        1,0,0,8,   0,0,0,0,
+        2,0,0,8,   0,0,0,0,
+    ]),
+    2: bytearray([
+        # Suite 2: RAKP-HMAC-SHA1 (0x01), HMAC-SHA1-96 (0x01), none
+        0,0,0,8,   1,0,0,0,
+        1,0,0,8,   1,0,0,0,
+        2,0,0,8,   0,0,0,0,
+    ]),
     3: bytearray([
-        0, 0, 0, 8, 1, 0, 0, 0,  # table 13-17, SHA-1
-        1, 0, 0, 8, 1, 0, 0, 0,  # SHA-1 integrity
-        2, 0, 0, 8, 1, 0, 0, 0,  # AES privacy
+        # Suite 3: RAKP-HMAC-SHA1 (0x01), HMAC-SHA1-96 (0x01), AES-CBC-128 (0x01)
+        0,0,0,8,   1,0,0,0,
+        1,0,0,8,   1,0,0,0,
+        2,0,0,8,   1,0,0,0,
+    ]),
+    4: bytearray([
+        # Suite 4: RAKP-HMAC-SHA1 (0x01), HMAC-SHA1-96 (0x01), xRC4-128 (0x02)
+        0,0,0,8,   1,0,0,0,
+        1,0,0,8,   1,0,0,0,
+        2,0,0,8,   2,0,0,0,
+    ]),
+    5: bytearray([
+        # Suite 5: RAKP-HMAC-SHA1 (0x01), HMAC-SHA1-96 (0x01), xRC4-40 (0x03)
+        0,0,0,8,   1,0,0,0,
+        1,0,0,8,   1,0,0,0,
+        2,0,0,8,   3,0,0,0,
     ]),
     6: bytearray([
-        0, 0, 0, 8, 3, 0, 0, 0,  # table 13-17, SHA-256
-        1, 0, 0, 8, 4, 0, 0, 0,  # SHA-256-128 integrity
-        2, 0, 0, 8, 1, 0, 0, 0,  # AES privacy
-    ])
+        # Suite 6: RAKP-HMAC-MD5 (0x02), none, none
+        0,0,0,8,   2,0,0,0,
+        1,0,0,8,   0,0,0,0,
+        2,0,0,8,   0,0,0,0,
+    ]),
+    7: bytearray([
+        # Suite 7: RAKP-HMAC-MD5 (0x02), HMAC-MD5-128 (0x02), none
+        0,0,0,8,   2,0,0,0,
+        1,0,0,8,   2,0,0,0,
+        2,0,0,8,   0,0,0,0,
+    ]),
+    8: bytearray([
+        # Suite 8: RAKP-HMAC-MD5 (0x02), HMAC-MD5-128 (0x02), AES-CBC-128 (0x01)
+        0,0,0,8,   2,0,0,0,
+        1,0,0,8,   2,0,0,0,
+        2,0,0,8,   1,0,0,0,
+    ]),
+    9: bytearray([
+        # Suite 9: RAKP-HMAC-MD5 (0x02), HMAC-MD5-128 (0x02), xRC4-128 (0x02)
+        0,0,0,8,   2,0,0,0,
+        1,0,0,8,   2,0,0,0,
+        2,0,0,8,   2,0,0,0,
+    ]),
+    10: bytearray([
+        # Suite 10: RAKP-HMAC-MD5 (0x02), HMAC-MD5-128 (0x02), xRC4-40 (0x03)
+        0,0,0,8,   2,0,0,0,
+        1,0,0,8,   2,0,0,0,
+        2,0,0,8,   3,0,0,0,
+    ]),
+    11: bytearray([
+        # Suite 11: RAKP-HMAC-MD5 (0x02), MD5-128 (0x03), none
+        0,0,0,8,   2,0,0,0,
+        1,0,0,8,   3,0,0,0,
+        2,0,0,8,   0,0,0,0,
+    ]),
+    12: bytearray([
+        # Suite 12: RAKP-HMAC-MD5 (0x02), MD5-128 (0x03), AES-CBC-128 (0x01)
+        0,0,0,8,   2,0,0,0,
+        1,0,0,8,   3,0,0,0,
+        2,0,0,8,   1,0,0,0,
+    ]),
+    13: bytearray([
+        # Suite 13: RAKP-HMAC-MD5 (0x02), MD5-128 (0x03), xRC4-128 (0x02)
+        0,0,0,8,   2,0,0,0,
+        1,0,0,8,   3,0,0,0,
+        2,0,0,8,   2,0,0,0,
+    ]),
+    14: bytearray([
+        # Suite 14: RAKP-HMAC-MD5 (0x02), MD5-128 (0x03), xRC4-40 (0x03)
+        0,0,0,8,   2,0,0,0,
+        1,0,0,8,   3,0,0,0,
+        2,0,0,8,   3,0,0,0,
+    ]),
+    15: bytearray([
+        # Suite 15: RAKP-HMAC-SHA256 (0x03), none, none
+        0,0,0,8,   3,0,0,0,
+        1,0,0,8,   0,0,0,0,
+        2,0,0,8,   0,0,0,0,
+    ]),
+    16: bytearray([
+        # Suite 16: RAKP-HMAC-SHA256 (0x03), HMAC-SHA256-128 (0x04), none
+        0,0,0,8,   3,0,0,0,
+        1,0,0,8,   4,0,0,0,
+        2,0,0,8,   0,0,0,0,
+    ]),
+    17: bytearray([
+        # Suite 17: RAKP-HMAC-SHA256 (0x03), HMAC-SHA256-128 (0x04), AES-CBC-128 (0x01)
+        0,0,0,8,   3,0,0,0,
+        1,0,0,8,   4,0,0,0,
+        2,0,0,8,   1,0,0,0,
+    ]),
 }
 
 print("Available cipher suites:")
@@ -89,7 +187,7 @@ class ServerSession(ipmisession.Session):
 
         self.requested_suite_data = suites[matching_suite]
 
-        integrity = int.from_bytes(self.requested_suite_data[4:8], "big")
+        integrity = int.from_bytes(self.requested_suite_data[4:8], 'little')
 
         print("Integrity algorithm selected: {}".format(integrity))
 

--- a/pyghmi/ipmi/private/serversession.py
+++ b/pyghmi/ipmi/private/serversession.py
@@ -187,11 +187,11 @@ class ServerSession(ipmisession.Session):
         # not implemented yet
         # auth  = int.from_bytes(self.requested_suite_data[4:8], 'little')
 
-        self.integrityalgo: int.from_bytes(self.requested_suite_data[12:16], 'little')
-        print(f"Integrity algorithm selected: {format(self.integrityalgo)}")
+        self.requested_integrityalgo = int.from_bytes(self.requested_suite_data[12:16], "little")
+        print( f"Integrity algorithm selected: {format(self.requested_integrityalgo)}")
 
-        self.confalgo: int  = int.from_bytes(self.requested_suite_data[20:24], 'little')
-        print(f"Confidentiality algorithm selected: {format(self.confalgo)}")
+        self.requested_confalgo = int.from_bytes(self.requested_suite_data[20:24], "little")
+        print(f"Confidentiality algorithm selected: {format(self.requested_confalgo)}")
 
         algo_map = {
             1: (hashlib.sha1, 12),
@@ -202,8 +202,8 @@ class ServerSession(ipmisession.Session):
             6: (hashlib.sha512, 24),
         }
         try:
-            self.currhashlib = algo_map[self.integrityalgo][0]
-            self.currhashlen = algo_map[self.integrityalgo][1]
+            self.currhashlib = algo_map[self.requested_integrityalgo][0]
+            self.currhashlen: int = algo_map[self.requested_integrityalgo][1]
         except KeyError:
             return bytearray([clienttag, 17])
 

--- a/pyghmi/ipmi/private/serversession.py
+++ b/pyghmi/ipmi/private/serversession.py
@@ -191,20 +191,26 @@ class ServerSession(ipmisession.Session):
 
         print("Integrity algorithm selected: {}".format(integrity))
 
-        if integrity == 0x00000001:
+        if integrity == 2:
+            # hmac-md5-128
+            self.currhashlib = hashlib.md5
+            self.currhashlen = 16
+        elif integrity == 1:
+            # hmac-sha1-96
             self.currhashlib = hashlib.sha1
             self.currhashlen = 12
-        elif integrity == 0x00000004:
+        elif integrity == 4:
+            # hmac-sha256-128
             self.currhashlib = hashlib.sha256
             self.currhashlen = 16
-        elif integrity == 0x00000002:
-            self.integrityalgo = hashlib.md5
-            self.currhashlen = 16
+
         else:
             # throw an error here, unsupported integrity algo
             # null is not supported, so we don't support suite 0
             # though we include it in the suite list for reference
             raise ValueError("Unsupported integrity algorithm: {}".format(integrity))
+
+        self.integrityalgo: int = integrity
 
         response = (bytearray([clienttag, 0, self.privlevel, 0])
             + self.clientsessionid + self.managedsessionid

--- a/pyghmi/ipmi/private/serversession.py
+++ b/pyghmi/ipmi/private/serversession.py
@@ -76,6 +76,8 @@ class ServerSession(ipmisession.Session):
     def create_open_session_response(self, request):
         requested_suite = request[8:24+8]
 
+        print("Requested cipher suite: {}".format(requested_suite.hex()))
+
         matching_suite = None
         for key, value in suites.items():
             if value == requested_suite:
@@ -100,6 +102,9 @@ class ServerSession(ipmisession.Session):
         self.privlevel = 4
 
         self.requested_suite = matching_suite
+
+        print("Requested cipher suite: {}".format(self.requested_suite))
+
         self.requested_suite_data = suites[matching_suite]
 
         integrity = int.from_bytes(self.requested_suite_data[4:8], "big")

--- a/pyghmi/ipmi/private/serversession.py
+++ b/pyghmi/ipmi/private/serversession.py
@@ -170,6 +170,12 @@ class ServerSession(ipmisession.Session):
         if matching_suite is None:
             response = bytearray([clienttag, 17])
             return response
+
+        # if matching_suite isn't in 3, 8, 17 send 11h error aka decimal 17
+        # this is temporary whilst we figure the rest out
+        if matching_suite not in (3, 8, 17):
+            response = bytearray([clienttag, 17])
+            return response
         
         # role = request[1]
         self.clientsessionid = request[4:8]

--- a/pyghmi/ipmi/private/serversession.py
+++ b/pyghmi/ipmi/private/serversession.py
@@ -210,7 +210,7 @@ class ServerSession(ipmisession.Session):
             # though we include it in the suite list for reference
             raise ValueError("Unsupported integrity algorithm: {}".format(integrity))
 
-        self.integrityalgo: int = integrity
+        #self.integrityalgo: int = integrity
 
         response = (bytearray([clienttag, 0, self.privlevel, 0])
             + self.clientsessionid + self.managedsessionid

--- a/pyghmi/ipmi/private/serversession.py
+++ b/pyghmi/ipmi/private/serversession.py
@@ -28,24 +28,28 @@ import uuid
 import pyghmi.ipmi.private.constants as constants
 import pyghmi.ipmi.private.session as ipmisession
 
-def make_suite(integrity: int, confidentiality: int, rakp: int) -> bytes:
-    """Creates a cipher suite byte array.
-
-    :param integrity: The integrity algorithm code (e.g., 0x04 for HMAC-MD5)
-    :param confidentiality: The confidentiality algorithm code (e.g., 0x01 for AES-128)
-    :param rakp: The RAKP algorithm code (e.g., 0x03 for AES-128)
-    :return: A byte array representing the cipher suite
+def make_suite(rakp: int, integ: int, conf: int) -> bytearray:
     """
-    return struct.pack('>IIBB', integrity, confidentiality, rakp, 0, 0)
+    Build the 24-byte "ipmitool" format for an IPMI 2.0 LAN+ cipher suite.
+    Each 8-byte row is:
+      Row 0: [0, 0, 0, rakp] + [integ, 0, 0, 0]
+      Row 1: [integ, 0, 0, rakp] + [integ, 0, 0, 0]
+      Row 2: [conf, 0, 0, rakp] + [integ, 0, 0, 0]
+    """
+    row0 = bytes([0x00, 0x00, 0x00, rakp, integ, 0x00, 0x00, 0x00])
+    row1 = bytes([integ, 0x00, 0x00, rakp, integ, 0x00, 0x00, 0x00])
+    row2 = bytes([conf,  0x00, 0x00, rakp, integ, 0x00, 0x00, 0x00])
+    return bytearray(row0 + row1 + row2)
 
-suites = {
+# Standard non-OEM suites (ID: (rakp, integ, conf)):
+suites: dict[int, bytearray] = {
     0:  make_suite(0x00, 0x00, 0x00),  # Null/no-auth/no-int/no-conf
     1:  make_suite(0x04, 0x02, 0x00),  # HMAC-MD5, no privacy
     2:  make_suite(0x08, 0x01, 0x07),  # HMAC-SHA1 + DES
     3:  make_suite(0x08, 0x01, 0x01),  # HMAC-SHA1 + AES-128
     6:  make_suite(0x0B, 0x04, 0x01),  # HMAC-SHA256 + AES-128
     7:  make_suite(0x08, 0x01, 0x03),  # HMAC-SHA1 + AES-256
-    8:  make_suite(0x0B, 0x04, 0x01),  # HMAC-SHA256 + AES-128  (identical IDs to 6 in this case)
+    8:  make_suite(0x0B, 0x04, 0x01),  # HMAC-SHA256 + AES-128 (same as 6)
     11: make_suite(0x08, 0x01, 0x04),  # HMAC-SHA1 + 3DES
     12: make_suite(0x0B, 0x04, 0x02),  # HMAC-SHA256 + AES-192
     15: make_suite(0x08, 0x01, 0x05),  # HMAC-SHA1 + AES-128-GCM

--- a/pyghmi/ipmi/private/serversession.py
+++ b/pyghmi/ipmi/private/serversession.py
@@ -157,10 +157,11 @@ class ServerSession(ipmisession.Session):
         return object.__new__(cls)
 
     def create_open_session_response(self, request: bytearray) -> bytearray:
-        requested_suite = request[8:24+8]
 
+        requested_suite = request[8:24+8]
         print(f"Requested cipher suite: {format(requested_suite.hex())}")
 
+        # this is legacy code and can be made much simpler - just not right now
         matching_suite = None
         for key, value in suites.items():
             if value == requested_suite:
@@ -175,16 +176,10 @@ class ServerSession(ipmisession.Session):
         
         # role = request[1]
         self.clientsessionid = request[4:8]
-        # TODO(jbjohnso): intelligently handle integrity/auth/conf
-        # for now, forcibly do cipher suite 3
         self.managedsessionid: bytes = os.urandom(4)
-        # table 13-17, 1 for now (hmac-sha1), 3 should also be supported
-        # table 13-18, integrity, 1 for now is hmac-sha1-96, 4 is sha256
-        # confidentiality: 1 is aes-cbc-128, the only one
         self.privlevel = 4
 
         self.requested_suite = matching_suite
-
         print(f"Requested cipher suite: {format(self.requested_suite)}")
 
         self.requested_suite_data = suites[matching_suite]

--- a/pyghmi/ipmi/private/serversession.py
+++ b/pyghmi/ipmi/private/serversession.py
@@ -190,11 +190,15 @@ class ServerSession(ipmisession.Session):
         algo_map = {
             1: (hashlib.sha1, 12),
             2: (hashlib.md5, 16),
-            3: (hashlib.sha256, 16)
+            #3: (hashlib.md5, 16), # disabled because not hmac
+            4: (hashlib.sha256, 16),
+            5: (hashlib.sha384, 24),
+            6: (hashlib.sha512, 24),
         }
         try:
             self.currhashlib
             self.currhashlen = algo_map[integrity]
+            self.integrityalgo = integrity
         except KeyError:
             return bytearray([clienttag, 17])
 

--- a/pyghmi/ipmi/private/serversession.py
+++ b/pyghmi/ipmi/private/serversession.py
@@ -28,6 +28,20 @@ import uuid
 import pyghmi.ipmi.private.constants as constants
 import pyghmi.ipmi.private.session as ipmisession
 
+suites = {
+    0:  make_suite(0x00, 0x00, 0x00),  # Null/no-auth/no-int/no-conf
+    1:  make_suite(0x04, 0x02, 0x00),  # HMAC-MD5, no privacy
+    2:  make_suite(0x08, 0x01, 0x07),  # HMAC-SHA1 + DES
+    3:  make_suite(0x08, 0x01, 0x01),  # HMAC-SHA1 + AES-128
+    6:  make_suite(0x0B, 0x04, 0x01),  # HMAC-SHA256 + AES-128
+    7:  make_suite(0x08, 0x01, 0x03),  # HMAC-SHA1 + AES-256
+    8:  make_suite(0x0B, 0x04, 0x01),  # HMAC-SHA256 + AES-128  (identical IDs to 6 in this case)
+    11: make_suite(0x08, 0x01, 0x04),  # HMAC-SHA1 + 3DES
+    12: make_suite(0x0B, 0x04, 0x02),  # HMAC-SHA256 + AES-192
+    15: make_suite(0x08, 0x01, 0x05),  # HMAC-SHA1 + AES-128-GCM
+    16: make_suite(0x0B, 0x04, 0x05),  # HMAC-SHA256 + AES-128-GCM
+    17: make_suite(0x0B, 0x04, 0x03),  # HMAC-SHA256 + AES-256
+}
 
 class ServerSession(ipmisession.Session):
     def __new__(cls, authdata, kg, clientaddr, netsocket, request, uuid,
@@ -40,18 +54,6 @@ class ServerSession(ipmisession.Session):
 
     def create_open_session_response(self, request):
         requested_suite = request[8:24+8]
-        suites = {
-            3: bytearray([
-                0, 0, 0, 8, 1, 0, 0, 0,  # table 13-17, SHA-1
-                1, 0, 0, 8, 1, 0, 0, 0,  # SHA-1 integrity
-                2, 0, 0, 8, 1, 0, 0, 0,  # AES privacy
-            ]),
-            6: bytearray([
-                0, 0, 0, 8, 3, 0, 0, 0,  # table 13-17, SHA-256
-                1, 0, 0, 8, 4, 0, 0, 0,  # SHA-256-128 integrity
-                2, 0, 0, 8, 1, 0, 0, 0,  # AES privacy
-            ])
-        }
 
         matching_suite = None
         for key, value in suites.items():
@@ -79,12 +81,22 @@ class ServerSession(ipmisession.Session):
         self.requested_suite = matching_suite
         self.requested_suite_data = suites[matching_suite]
 
-        if self.requested_suite == 3:
+        integrity = int.from_bytes(self.requested_suite_data[4:8], "big")
+
+        if integrity == 0x00000001:
             self.currhashlib = hashlib.sha1
             self.currhashlen = 12
-        elif self.requested_suite == 6:
+        elif integrity == 0x00000004:
             self.currhashlib = hashlib.sha256
             self.currhashlen = 16
+        elif integrity == 0x00000002:
+            self.integrityalgo = hashlib.md5
+            self.currhashlen = 16
+        else:
+            # throw an error here, unsupported integrity algo
+            # null is not supported, so we don't support suite 0
+            # though we include it in the suite list for reference
+            raise ValueError("Unsupported integrity algorithm: {}".format(integrity))
 
         response = (bytearray([clienttag, 0, self.privlevel, 0])
             + self.clientsessionid + self.managedsessionid
@@ -433,3 +445,21 @@ class IpmiServer(object):
 
     def logout(self):
         pass
+
+# used to build our suite records, which are 24 bytes long
+def make_suite(rakp_id, integ_id, conf_id):
+    """
+    Build a 24-byte IPMI LAN+ cipher-suite record by repeating
+    the three 32-bit (big-endian) IDs twice.
+    """
+    trio = (
+        rakp_id.to_bytes(4, "big") +
+        integ_id.to_bytes(4, "big") +
+        conf_id.to_bytes(4, "big")
+    )
+
+    # 8 bytes × 2 = 16 bytes? No—8 bytes × 3 = 24 bytes
+    # each (RAKP, Integrity, Confidentiality) is 3 × 4 = 12 bytes,
+    # so “trio” is 12 bytes, and “trio + trio” is 24 bytes total.
+    # (RAKP.to_bytes(4) + Integ.to_bytes(4) + Conf.to_bytes(4)) is 12 bytes; repeating it gives 24.
+    return trio + trio

--- a/pyghmi/ipmi/private/serversession.py
+++ b/pyghmi/ipmi/private/serversession.py
@@ -27,124 +27,16 @@ import uuid
 
 import pyghmi.ipmi.private.constants as constants
 import pyghmi.ipmi.private.session as ipmisession
+from pyghmi.ipmi.private.cipher_suite import (
+    CIPHER_SUITE_PARAMS,
+    build_cipher_suite,
+)
 
 suites: dict[int, bytearray] = {
-    0: bytearray([
-        # Suite 0: “no auth, no integ, no conf”
-        0,0,0,8,   0,0,0,0,  
-        1,0,0,8,   0,0,0,0,  
-        2,0,0,8,   0,0,0,0,
-    ]),
-    1: bytearray([
-        # Suite 1: RAKP-HMAC-SHA1 (0x01), none, none
-        0,0,0,8,   1,0,0,0,
-        1,0,0,8,   0,0,0,0,
-        2,0,0,8,   0,0,0,0,
-    ]),
-    2: bytearray([
-        # Suite 2: RAKP-HMAC-SHA1 (0x01), HMAC-SHA1-96 (0x01), none
-        0,0,0,8,   1,0,0,0,
-        1,0,0,8,   1,0,0,0,
-        2,0,0,8,   0,0,0,0,
-    ]),
-    3: bytearray([
-        # Suite 3: RAKP-HMAC-SHA1 (0x01), HMAC-SHA1-96 (0x01), AES-CBC-128 (0x01)
-        0,0,0,8,   1,0,0,0,
-        1,0,0,8,   1,0,0,0,
-        2,0,0,8,   1,0,0,0,
-    ]),
-    4: bytearray([
-        # Suite 4: RAKP-HMAC-SHA1 (0x01), HMAC-SHA1-96 (0x01), xRC4-128 (0x02)
-        0,0,0,8,   1,0,0,0,
-        1,0,0,8,   1,0,0,0,
-        2,0,0,8,   2,0,0,0,
-    ]),
-    5: bytearray([
-        # Suite 5: RAKP-HMAC-SHA1 (0x01), HMAC-SHA1-96 (0x01), xRC4-40 (0x03)
-        0,0,0,8,   1,0,0,0,
-        1,0,0,8,   1,0,0,0,
-        2,0,0,8,   3,0,0,0,
-    ]),
-    6: bytearray([
-        # Suite 6: RAKP-HMAC-MD5 (0x02), none, none
-        0,0,0,8,   2,0,0,0,
-        1,0,0,8,   0,0,0,0,
-        2,0,0,8,   0,0,0,0,
-    ]),
-    7: bytearray([
-        # Suite 7: RAKP-HMAC-MD5 (0x02), HMAC-MD5-128 (0x02), none
-        0,0,0,8,   2,0,0,0,
-        1,0,0,8,   2,0,0,0,
-        2,0,0,8,   0,0,0,0,
-    ]),
-    8: bytearray([
-        # Suite 8: RAKP-HMAC-MD5 (0x02), HMAC-MD5-128 (0x02), AES-CBC-128 (0x01)
-        0,0,0,8,   2,0,0,0,
-        1,0,0,8,   2,0,0,0,
-        2,0,0,8,   1,0,0,0,
-    ]),
-    9: bytearray([
-        # Suite 9: RAKP-HMAC-MD5 (0x02), HMAC-MD5-128 (0x02), xRC4-128 (0x02)
-        0,0,0,8,   2,0,0,0,
-        1,0,0,8,   2,0,0,0,
-        2,0,0,8,   2,0,0,0,
-    ]),
-    10: bytearray([
-        # Suite 10: RAKP-HMAC-MD5 (0x02), HMAC-MD5-128 (0x02), xRC4-40 (0x03)
-        0,0,0,8,   2,0,0,0,
-        1,0,0,8,   2,0,0,0,
-        2,0,0,8,   3,0,0,0,
-    ]),
-    11: bytearray([
-        # Suite 11: RAKP-HMAC-MD5 (0x02), MD5-128 (0x03), none
-        0,0,0,8,   2,0,0,0,
-        1,0,0,8,   3,0,0,0,
-        2,0,0,8,   0,0,0,0,
-    ]),
-    12: bytearray([
-        # Suite 12: RAKP-HMAC-MD5 (0x02), MD5-128 (0x03), AES-CBC-128 (0x01)
-        0,0,0,8,   2,0,0,0,
-        1,0,0,8,   3,0,0,0,
-        2,0,0,8,   1,0,0,0,
-    ]),
-    13: bytearray([
-        # Suite 13: RAKP-HMAC-MD5 (0x02), MD5-128 (0x03), xRC4-128 (0x02)
-        0,0,0,8,   2,0,0,0,
-        1,0,0,8,   3,0,0,0,
-        2,0,0,8,   2,0,0,0,
-    ]),
-    14: bytearray([
-        # Suite 14: RAKP-HMAC-MD5 (0x02), MD5-128 (0x03), xRC4-40 (0x03)
-        0,0,0,8,   2,0,0,0,
-        1,0,0,8,   3,0,0,0,
-        2,0,0,8,   3,0,0,0,
-    ]),
-    15: bytearray([
-        # Suite 15: RAKP-HMAC-SHA256 (0x03), none, none
-        0,0,0,8,   3,0,0,0,
-        1,0,0,8,   0,0,0,0,
-        2,0,0,8,   0,0,0,0,
-    ]),
-    16: bytearray([
-        # Suite 16: RAKP-HMAC-SHA256 (0x03), HMAC-SHA256-128 (0x04), none
-        0,0,0,8,   3,0,0,0,
-        1,0,0,8,   4,0,0,0,
-        2,0,0,8,   0,0,0,0,
-    ]),
-    17: bytearray([
-        # Suite 17: RAKP-HMAC-SHA256 (0x03), HMAC-SHA256-128 (0x04), AES-CBC-128 (0x01)
-        0,0,0,8,   3,0,0,0,
-        1,0,0,8,   4,0,0,0,
-        2,0,0,8,   1,0,0,0,
-    ]),
-}
+    sid: build_cipher_suite(*algos)
+    for sid, algos in CIPHER_SUITE_PARAMS.items()
 
-supported_suites: list[int] = [3, 8, 17]
-
-print("Available cipher suites:")
-for key, value in suites.items():
-    print(f"Suite {key}: {value.hex()} (Rakp: {value[0:4].hex()}, "
-          f"Integ: {value[4:8].hex()}, Conf: {value[8:12].hex()})")
+supported_suites: list[int] = list(suites.keys())
 
 class ServerSession(ipmisession.Session):
 
@@ -158,8 +50,7 @@ class ServerSession(ipmisession.Session):
 
     def create_open_session_response(self, request: bytearray) -> bytearray:
 
-        requested_suite = request[8:24+8]
-        print(f"Requested cipher suite: {format(requested_suite.hex())}")
+        requested_suite = request[8:24 + 8]
 
         # this is legacy code and can be made much simpler - just not right now
         matching_suite = None
@@ -170,49 +61,69 @@ class ServerSession(ipmisession.Session):
 
         clienttag = int(request[0])
 
-        # if the requested suite doesn't match one we support send 11h error aka decimal 17
+        # if unsupported, return error 0x11 (decimal 17)
         if matching_suite is None or matching_suite not in supported_suites:
             return bytearray([clienttag, 17])
-        
+
         # role = request[1]
         self.clientsessionid = request[4:8]
         self.managedsessionid: bytes = os.urandom(4)
         self.privlevel = 4
 
         self.requested_suite = matching_suite
-        print(f"Requested cipher suite: {format(self.requested_suite)}")
 
         self.requested_suite_data = suites[matching_suite]
 
-        # not implemented yet
-        # auth  = int.from_bytes(self.requested_suite_data[4:8], 'little')
+        self.requested_authalgo = int.from_bytes(
+            self.requested_suite_data[4:8], "little")
 
-        self.requested_integrityalgo = int.from_bytes(self.requested_suite_data[12:16], "little")
-        print( f"Integrity algorithm selected: {format(self.requested_integrityalgo)}")
+        if self.requested_authalgo not in (1, 2, 3):
+            return bytearray([clienttag, 17])
 
-        self.requested_confalgo = int.from_bytes(self.requested_suite_data[20:24], "little")
-        print(f"Confidentiality algorithm selected: {format(self.requested_confalgo)}")
+        self.requested_integrityalgo = int.from_bytes(
+            self.requested_suite_data[12:16], "little"
+        )
+
+        self.requested_confalgo = int.from_bytes(
+            self.requested_suite_data[20:24], "little"
+        )
 
         algo_map = {
             1: (hashlib.sha1, 12),
             2: (hashlib.md5, 16),
-            #3: (hashlib.md5, 16), # disabled because not hmac
+            # 3: (hashlib.md5, 16), # disabled because not hmac
             4: (hashlib.sha256, 16),
             5: (hashlib.sha384, 24),
             6: (hashlib.sha512, 24),
         }
+
+        if self.requested_confalgo not in ipmisession.CONF_ALGOS:
+            return bytearray([clienttag, 17])
+
+        # Ensure authentication and integrity algorithms align
+        auth_map = {1: hashlib.sha1, 2: hashlib.md5, 3: hashlib.sha256}
+        requested_hash = auth_map.get(self.requested_authalgo)
+        integ_entry = algo_map.get(self.requested_integrityalgo, (None,))
+        if requested_hash != integ_entry[0]:
+            return bytearray([clienttag, 17])
+
         try:
             self.currhashlib = algo_map[self.requested_integrityalgo][0]
             self.currhashlen: int = algo_map[self.requested_integrityalgo][1]
         except KeyError:
             return bytearray([clienttag, 17])
 
-        response = bytearray(bytearray([clienttag, 0, self.privlevel, 0])
-            + self.clientsessionid + self.managedsessionid
-            + self.requested_suite_data)
+        response = bytearray(
+            bytearray([clienttag, 0, self.privlevel, 0])
+            + self.clientsessionid
+            + self.managedsessionid
+            + self.requested_suite_data
+        )
         return response
 
-    def __init__(self, authdata, kg, clientaddr, netsocket, request, uuid, bmc):
+    def __init__(
+        self, authdata, kg, clientaddr, netsocket, request, uuid, bmc
+    ):
         # begin conversation per RMCP+ open session request
 
         self.requested_suite = 0
@@ -309,12 +220,18 @@ class ServerSession(ipmisession.Session):
                             + self.username, self.currhashlib).digest()
         self.k1 = hmac.new(self.sik, b'\x01' * 20, self.currhashlib).digest()
         self.k2 = hmac.new(self.sik, b'\x02' * 20, self.currhashlib).digest()
-        self.aeskey = self.k2[0:16]
+        confinfo = ipmisession.CONF_ALGOS.get(
+            self.requested_confalgo,
+            ipmisession.CONF_ALGOS[0]
+        )
+        keylen = confinfo.get("keylen", 0)
+        self.aeskey = self.k2[:keylen] if keylen else None
         hmacdata = (self.Rc + self.clientsessionid
                     + struct.pack("2B", self.rolem, len(self.username))
                     + self.username)
-        expectedauthcode = hmac.new(self.kuid, bytes(hmacdata), self.currhashlib
-                                    ).digest()
+        expectedauthcode = (
+            hmac.new(self.kuid, bytes(hmacdata), self.currhashlib).digest()
+        )
         authcode = struct.pack("%dB" % len(data[8:]), *data[8:])
         if expectedauthcode != authcode:
             # TODO(jjohnson2): RMCP error back at invalid rakp3
@@ -352,7 +269,10 @@ class ServerSession(ipmisession.Session):
             [tagvalue, statuscode, 0, 0]) + self.clientsessionid
         hmacdata = self.Rm + self.managedsessionid + self.uuiddata
         hmacdata = struct.pack('%dB' % len(hmacdata), *hmacdata)
-        authdata = hmac.new(self.sik, hmacdata, self.currhashlib).digest()[:self.currhashlen]
+        authdata = (
+            hmac.new(self.sik, hmacdata, self.currhashlib)
+            .digest()[:self.currhashlen]
+        )
         payload += authdata
         self.send_payload(payload, constants.payload_types['rakp4'],
                           retry=False)

--- a/pyghmi/ipmi/private/serversession.py
+++ b/pyghmi/ipmi/private/serversession.py
@@ -187,6 +187,9 @@ class ServerSession(ipmisession.Session):
         integrity: int = int.from_bytes(self.requested_suite_data[4:8], 'little')
         print(f"Integrity algorithm selected: {format(integrity)}")
 
+        self.confalgo: int = int.from_bytes(self.requested_suite_data[8:12], 'little')
+        print(f"Confidentiality algorithm selected: {format(self.confalgo)}")
+
         algo_map = {
             1: (hashlib.sha1, 12),
             2: (hashlib.md5, 16),

--- a/pyghmi/ipmi/private/session.py
+++ b/pyghmi/ipmi/private/session.py
@@ -1129,7 +1129,7 @@ class Session(object):
             ])
             self.currhashlib = hashlib.sha1
             self.currhashlen = 12
-        else:
+        elif self.attemptedhash == 256:
             data += bytearray([
                 0, 0, 0, 8, 3, 0, 0, 0,  # table 13-17, SHA-256
                 1, 0, 0, 8, 4, 0, 0, 0,  # SHA-256-128 integrity
@@ -1138,6 +1138,8 @@ class Session(object):
             ])
             self.currhashlib = hashlib.sha256
             self.currhashlen = 16
+        else:
+            raise exc.IpmiException('Unsupported attemptedhash')
         self.sessioncontext = 'OPENSESSION'
         self.lastpayload = None
         self.send_payload(

--- a/pyghmi/ipmi/private/session.py
+++ b/pyghmi/ipmi/private/session.py
@@ -1698,7 +1698,8 @@ class Session(object):
             return
         self.sessionid = self.pendingsessionid
         self.integrityalgo = self.attemptedhash
-        self.confalgo = 'aes'
+        # AES-CBC-128 is currently the only supported confidentiality algorithm
+        self.confalgo = 1
         self.sequencenumber = 1
         self.sessioncontext = 'ESTABLISHED'
         self.lastpayload = None

--- a/pyghmi/ipmi/private/session.py
+++ b/pyghmi/ipmi/private/session.py
@@ -31,12 +31,22 @@ from cryptography.hazmat.primitives.ciphers import algorithms
 from cryptography.hazmat.primitives.ciphers import Cipher
 from cryptography.hazmat.primitives.ciphers import modes
 
+from cryptography.hazmat.primitives.ciphers.base import AEADEncryptionContext
 import pyghmi.exceptions as exc
 from pyghmi.ipmi.private import constants
 from pyghmi.ipmi.private import util
 from pyghmi.ipmi.private.util import _monotonic_time
 from pyghmi.ipmi.private.util import get_ipmi_error
 
+# confidentiality algorithm support data
+CONF_ALGOS = {
+    0: {"name": "none", "keylen": 0, "ivlen": 0, "pad": False, "encrypt": None},
+    1: {"name": "aes-cbc-128", "keylen": 16, "ivlen": 16, "pad": True, "algo": algorithms.AES},
+    2: {"name": "xrc4-128", "keylen": 16, "ivlen": 0, "pad": False},
+    3: {"name": "xrc4-40",  "keylen": 5,  "ivlen": 0, "pad": False},
+    4: {"name": "aes-cbc-256", "keylen": 32, "ivlen": 16, "pad": True, "algo": algorithms.AES},
+    5: {"name": "aes-cbc-192", "keylen": 24, "ivlen": 16, "pad": True, "algo": algorithms.AES},
+}
 
 KEEPALIVE_SESSIONS = threading.RLock()
 WAITING_SESSIONS = threading.RLock()
@@ -872,6 +882,10 @@ class Session(object):
         self.send_payload(payload=ipmipayload, payload_type=payload_type,
                           retry=retry, delay_xmit=delay_xmit, timeout=timeout)
 
+    def _aespad(self, data):
+        pad_len = 16 - ((len(data) + 1) % 16)
+        return data + bytes([pad_len] * pad_len)
+
     def send_payload(self, payload=(), payload_type=None, retry=True,
                      delay_xmit=None, needskeepalive=False, timeout=None):
         """Send payload over the IPMI Session
@@ -931,33 +945,55 @@ class Session(object):
             if totlen in (56, 84, 112, 128, 156):
                 message.append(0)  # Legacy pad as mandated by ipmi spec
         elif self.ipmiversion == 2.0:
+
             psize = len(payload)
-            if self.confalgo:
-                pad = (psize + 1) % 16  # pad has to cope with one byte
-                # field like the _aespad function
-                if pad:  # if no pad needed, then we take no more action
-                    pad = 16 - pad
-                # new payload size grew according to pad
-                newpsize = psize + pad + 17
-                # size, plus pad length, plus 16 byte IV
-                # (Table 13-20)
-                message.append(newpsize & 0xff)
-                message.append(newpsize >> 8)
-                iv = os.urandom(16)
-                message += iv
-                payloadtocrypt = bytes(payload + _aespad(payload))
-                crypter = Cipher(
-                    algorithm=algorithms.AES(self.aeskey),
-                    mode=modes.CBC(iv),
-                    backend=self._crypto_backend
-                )
-                encryptor = crypter.encryptor()
-                message += encryptor.update(payloadtocrypt
-                                            ) + encryptor.finalize()
-            else:  # no confidetiality algorithm
-                message.append(psize & 0xff)
+            confinfo = CONF_ALGOS.get(self.confalgo, CONF_ALGOS[0])
+
+            pad = confinfo["pad"]
+            ivlen = confinfo["ivlen"]
+            keylen = confinfo["keylen"]
+
+            if self.confalgo == 0:
+                # No encryption
+                message.append(psize & 0xFF)
                 message.append(psize >> 8)
                 message += payload
+            else:
+                if pad:
+                    padded_payload = _aespad(payload)
+                else:
+                    padded_payload = payload
+
+                iv = os.urandom(ivlen) if ivlen else b""
+                newpsize = len(padded_payload) + 1 + ivlen  # padlen byte + IV + payload
+                message.append(newpsize & 0xFF)
+                message.append(newpsize >> 8)
+                if iv:
+                    message += iv
+
+                if self.confalgo in [1, 4, 5]:  # AES variants
+                    crypter = Cipher(
+                        algorithm=confinfo["algo"](self.aeskey),
+                        mode=modes.CBC(iv),
+                        backend=self._crypto_backend
+                    )
+                    encryptor = crypter.encryptor()
+                    enc = encryptor.update(padded_payload) + encryptor.finalize()
+                    message += enc
+
+                elif self.confalgo in [2, 3]:  # RC4 variants
+                    crypter = Cipher(
+                        algorithm=algorithms.ARC4(self.aeskey),
+                        mode=None,
+                        backend=self._crypto_backend
+                    )
+                    encryptor: AEADEncryptionContext = crypter.encryptor()
+                    message += encryptor.update(padded_payload)
+
+                else:
+                    # Unknown/conflicting algo
+                    raise ValueError(f"Unsupported confidentiality algorithm: {self.confalgo}")
+
             if self.integrityalgo:  # see table 13-8,
                 # RMCP+ packet format
                 # TODO(jbjohnso): SHA256 which is now

--- a/pyghmi/ipmi/private/session.py
+++ b/pyghmi/ipmi/private/session.py
@@ -956,12 +956,12 @@ class Session(object):
                 message += payload
             else:
                 if pad:
-                    padded_payload = _aespad(payload)
+                    padded_payload: bytearray = payload + _aespad(payload)
                 else:
-                    padded_payload = payload
+                    padded_payload: bytearray = payload
 
                 iv = os.urandom(ivlen) if ivlen else b""
-                newpsize = len(padded_payload) + 1 + ivlen  # padlen byte + IV + payload
+                newpsize = len(padded_payload) + ivlen
                 message.append(newpsize & 0xFF)
                 message.append(newpsize >> 8)
                 if iv:

--- a/pyghmi/ipmi/private/session.py
+++ b/pyghmi/ipmi/private/session.py
@@ -37,16 +37,43 @@ from pyghmi.ipmi.private import constants
 from pyghmi.ipmi.private import util
 from pyghmi.ipmi.private.util import _monotonic_time
 from pyghmi.ipmi.private.util import get_ipmi_error
+from pyghmi.ipmi.private.cipher_suite import build_cipher_suite
 
 # confidentiality algorithm support data
 CONF_ALGOS = {
-    0: {"name": "none", "keylen": 0, "ivlen": 0, "pad": False, "encrypt": None},
-    1: {"name": "aes-cbc-128", "keylen": 16, "ivlen": 16, "pad": True, "algo": algorithms.AES},
+    0: {
+        "name": "none",
+        "keylen": 0,
+        "ivlen": 0,
+        "pad": False,
+        "encrypt": None,
+    },
+    1: {
+        "name": "aes-cbc-128",
+        "keylen": 16,
+        "ivlen": 16,
+        "pad": True,
+        "algo": algorithms.AES,
+    },
     2: {"name": "xrc4-128", "keylen": 16, "ivlen": 0, "pad": False},
-    3: {"name": "xrc4-40",  "keylen": 5,  "ivlen": 0, "pad": False},
-    4: {"name": "aes-cbc-256", "keylen": 32, "ivlen": 16, "pad": True, "algo": algorithms.AES},
-    5: {"name": "aes-cbc-192", "keylen": 24, "ivlen": 16, "pad": True, "algo": algorithms.AES},
+    3: {"name": "xrc4-40", "keylen": 5, "ivlen": 0, "pad": False},
+    4: {
+        "name": "aes-cbc-256",
+        "keylen": 32,
+        "ivlen": 16,
+        "pad": True,
+        "algo": algorithms.AES,
+    },
+    5: {
+        "name": "aes-cbc-192",
+        "keylen": 24,
+        "ivlen": 16,
+        "pad": True,
+        "algo": algorithms.AES,
+    },
 }
+
+# Cipher suite data is defined in ``cipher_suite`` module.
 
 KEEPALIVE_SESSIONS = threading.RLock()
 WAITING_SESSIONS = threading.RLock()
@@ -485,14 +512,16 @@ class Session(object):
             return self
 
     def __init__(self,
-                 bmc,
-                 userid,
-                 password,
-                 port=623,
-                 kg=None,
-                 onlogon=None,
-                 privlevel=None,
-                 keepalive=True):
+        bmc,
+        userid,
+        password,
+        port=623,
+        kg=None,
+        onlogon=None,
+        privlevel=None,
+        keepalive=True,
+        confalgo=1
+    ):
         if hasattr(self, 'initialized'):
             # new found an existing session, do not corrupt it
             if onlogon is None:
@@ -553,6 +582,7 @@ class Session(object):
             self.kg = kg
         else:
             self.kg = self.password
+        self.confalgo = confalgo
         self.port = port
         if onlogon is None:
             self.async_ = False
@@ -623,7 +653,9 @@ class Session(object):
         #                 would show xCAT
         self.localsid = 2017673555
         self.remseqnumber = None
-        self.confalgo = 0
+        # Default to AES-CBC-128 confidentiality unless caller specified
+        if not hasattr(self, 'confalgo'):
+            self.confalgo = 1
         self.aeskey = None
         self.integrityalgo = 0
         self.attemptedhash = 256
@@ -947,7 +979,6 @@ class Session(object):
 
             pad = confinfo["pad"]
             ivlen = confinfo["ivlen"]
-            keylen = confinfo["keylen"]
 
             if self.confalgo == 0:
                 # No encryption
@@ -983,12 +1014,18 @@ class Session(object):
                         mode=None,
                         backend=self._crypto_backend
                     )
-                    encryptor: AEADEncryptionContext = crypter.encryptor()
+                    enc = (
+                        encryptor.update(padded_payload)
+                        + encryptor.finalize()
+                    )
                     message += encryptor.update(padded_payload)
 
                 else:
                     # Unknown/conflicting algo
-                    raise ValueError(f"Unsupported confidentiality algorithm: {self.confalgo}")
+                    raise ValueError(
+                        "Unsupported confidentiality algorithm: "
+                        f"{self.confalgo}"
+                    )
 
             if self.integrityalgo:  # see table 13-8,
                 # RMCP+ packet format
@@ -1150,28 +1187,21 @@ class Session(object):
             0, 0,  # reserved
         ])
         data += struct.pack("<I", self.localsid)
-        # auth 3 sha256
-        # integrity... 4 = sha256
         if self.attemptedhash == 1:
-            data += bytearray([
-                0, 0, 0, 8, 1, 0, 0, 0,  # table 13-17, SHA-1
-                1, 0, 0, 8, 1, 0, 0, 0,  # SHA-1 integrity
-                2, 0, 0, 8, 1, 0, 0, 0,  # AES privacy
-                # 2,0,0,8,0,0,0,0, #no privacy confalgo
-            ])
+            authalgo = 1
+            integralgo = 1
             self.currhashlib = hashlib.sha1
             self.currhashlen = 12
         elif self.attemptedhash == 256:
-            data += bytearray([
-                0, 0, 0, 8, 3, 0, 0, 0,  # table 13-17, SHA-256
-                1, 0, 0, 8, 4, 0, 0, 0,  # SHA-256-128 integrity
-                2, 0, 0, 8, 1, 0, 0, 0,  # AES privacy
-                # 2,0,0,8,0,0,0,0, #no privacy confalgo
-            ])
+            authalgo = 3
+            integralgo = 4
             self.currhashlib = hashlib.sha256
             self.currhashlen = 16
         else:
             raise exc.IpmiException('Unsupported attemptedhash')
+        
+        data += build_cipher_suite(authalgo, integralgo, self.confalgo)
+
         self.sessioncontext = 'OPENSESSION'
         self.lastpayload = None
         self.send_payload(
@@ -1636,7 +1666,9 @@ class Session(object):
                             + self.userid, self.currhashlib).digest()
         self.k1 = hmac.new(self.sik, b'\x01' * 20, self.currhashlib).digest()
         self.k2 = hmac.new(self.sik, b'\x02' * 20, self.currhashlib).digest()
-        self.aeskey = self.k2[0:16]
+        confinfo = CONF_ALGOS.get(self.confalgo, CONF_ALGOS[0])
+        keylen = confinfo.get("keylen", 0)
+        self.aeskey = self.k2[:keylen] if keylen else None
         self.sessioncontext = "EXPECTINGRAKP4"
         self.lastpayload = None
         self._send_rakp3()
@@ -1698,8 +1730,15 @@ class Session(object):
             return
         self.sessionid = self.pendingsessionid
         self.integrityalgo = self.attemptedhash
-        # AES-CBC-128 is currently the only supported confidentiality algorithm
-        self.confalgo = 1
+
+        # use the negotiated confidentiality algorithm
+        if not self.confalgo:
+            self.confalgo = 1
+        confinfo = CONF_ALGOS.get(self.confalgo, CONF_ALGOS[0])
+        keylen = confinfo.get("keylen", 0)
+        if keylen:
+            self.aeskey = self.k2[:keylen]
+
         self.sequencenumber = 1
         self.sessioncontext = 'ESTABLISHED'
         self.lastpayload = None

--- a/pyghmi/ipmi/private/session.py
+++ b/pyghmi/ipmi/private/session.py
@@ -882,10 +882,6 @@ class Session(object):
         self.send_payload(payload=ipmipayload, payload_type=payload_type,
                           retry=retry, delay_xmit=delay_xmit, timeout=timeout)
 
-    def _aespad(self, data):
-        pad_len = 16 - ((len(data) + 1) % 16)
-        return data + bytes([pad_len] * pad_len)
-
     def send_payload(self, payload=(), payload_type=None, retry=True,
                      delay_xmit=None, needskeepalive=False, timeout=None):
         """Send payload over the IPMI Session

--- a/pyghmi/ipmi/private/simplesession.py
+++ b/pyghmi/ipmi/private/simplesession.py
@@ -1199,7 +1199,8 @@ class Session(object):
             return
         self.sessionid = self.pendingsessionid
         self.integrityalgo = self.attemptedhash
-        self.confalgo = 'aes'
+        # AES-CBC-128 confidentiality is negotiated in open session
+        self.confalgo = 1
         self.sequencenumber = 1
         self.sessioncontext = 'ESTABLISHED'
         self.lastpayload = None


### PR DESCRIPTION
Attempt to match cipher suites better client and server rather than forcing one or presuming sha1.

Fixes a bug where Pyghmi is both client and server (acting as a fake BMC) to itself but refuses to correctly connect. These changes make it internally more rational, and also try to correctly use cipher suites rather than forcing a specific one in the code.

If a cipher suite isn't "supported" the server side now correctly sends an unsupported suite error as opposed to attempting to plough on anyway.